### PR TITLE
Update "Account for ZeroDivision error"

### DIFF
--- a/wizsdk/pixels.py
+++ b/wizsdk/pixels.py
@@ -96,9 +96,11 @@ class DeviceContext(Window):
             mBM, ctypes.sizeof(_BITMAP), ctypes.byref(bitmap)
         )
         # Account for the ZeroDevision error
-        if bits_transfered == 0:
-            # Reccurse until bits_transfered != 0.
-            return self.get_image(region)
+        bits_transfered = 0
+        while bits_transfered == 0:
+          bits_transfered = gdi32.GetObjectA(
+            mBM, ctypes.sizeof(_BITMAP), ctypes.byref(bitmap)
+          )
 
         bi = _BITMAPINFOHEADER()
         bi.biSize = ctypes.sizeof(_BITMAPINFOHEADER)

--- a/wizsdk/pixels.py
+++ b/wizsdk/pixels.py
@@ -98,9 +98,9 @@ class DeviceContext(Window):
         # Account for the ZeroDevision error
         bits_transfered = 0
         while bits_transfered == 0:
-          bits_transfered = gdi32.GetObjectA(
-            mBM, ctypes.sizeof(_BITMAP), ctypes.byref(bitmap)
-          )
+            bits_transfered = gdi32.GetObjectA(
+                mBM, ctypes.sizeof(_BITMAP), ctypes.byref(bitmap)
+            )
 
         bi = _BITMAPINFOHEADER()
         bi.biSize = ctypes.sizeof(_BITMAPINFOHEADER)


### PR DESCRIPTION
This change was suggested by SirOlaf#2881, all credit for it goes to him.
```bits_transfered = 0
while bits_transfered == 0:
  bits_transfered = gdi32.GetObjectA(
    mBM, ctypes.sizeof(_BITMAP), ctypes.byref(bitmap)
  )```